### PR TITLE
Put SourceIP condition on brokerpak-created credentials

### DIFF
--- a/services/sms.yml
+++ b/services/sms.yml
@@ -82,7 +82,7 @@ bind:
   user_inputs:
     - field_name: source_ips
       type: array
-      default:
+      default: # cloud.gov egress ips: https://cloud.gov/docs/management/static-egress/#cloudgov-egress-ranges
         - 52.222.122.97/32
         - 52.222.123.172/32
       details: IP Ranges that requests to SNS must come from

--- a/services/sms.yml
+++ b/services/sms.yml
@@ -79,7 +79,14 @@ provision:
     provider: "services/terraform/provision/provider.tf"
 bind:
   plan_inputs:
-  user_inputs: []
+  user_inputs:
+    - field_name: source_ips
+      type: array
+      default:
+        - 52.222.122.97/32
+        - 52.222.123.172/32
+      details: IP Ranges that requests to SNS must come from
+      prohibit_update: false
   computed_inputs:
     - name: region
       default: ${instance.details["region"]}

--- a/services/terraform/bind/main.tf
+++ b/services/terraform/bind/main.tf
@@ -32,6 +32,11 @@ resource "aws_iam_user_policy" "user_policy" {
           "sns:Publish"
         ]
         Resource = "*"
+        Condition = {
+          "ForAnyValue:IpAddress" = {
+            "aws:SourceIp" = var.source_ips
+          }
+        }
       }
     ]
   })

--- a/services/terraform/bind/terraform.tfvars-template
+++ b/services/terraform/bind/terraform.tfvars-template
@@ -1,3 +1,6 @@
-region        = "us-west-2"
-instance_name = "instance-yourname"
-user_name     = "csb-test"
+region    = "us-west-2"
+user_name = "csb-test"
+source_ips = [
+  "52.222.122.97/32",
+  "52.222.123.172/32"
+]

--- a/services/terraform/bind/variables.tf
+++ b/services/terraform/bind/variables.tf
@@ -3,3 +3,7 @@ variable "region" {
 }
 
 variable "user_name" { type = string }
+
+variable "source_ips" {
+  type = list(string)
+}


### PR DESCRIPTION
Defaults to [cloud.gov egress IPs](https://cloud.gov/docs/management/static-egress/#cloudgov-egress-ranges), but can be overridden in bind parameters.

Doing this enhances our SC-7 control compliance