### PR TITLE
notify-152 sms delivery receipts

### DIFF
--- a/services/terraform/bind/main.tf
+++ b/services/terraform/bind/main.tf
@@ -29,7 +29,8 @@ resource "aws_iam_user_policy" "user_policy" {
       {
         Effect = "Allow"
         Action = [
-          "sns:Publish"
+          "sns:Publish",
+          "logs:FilterLogEvents"
         ]
         Resource = "*"
         Condition = {
@@ -37,13 +38,6 @@ resource "aws_iam_user_policy" "user_policy" {
             "aws:SourceIp" = var.source_ips
           }
         }
-      },
-      {
-        Action: [
-          "logs:FilterLogEvents"
-        ],
-        Effect: "Allow",
-        Resource: "*"
       }
     ]
   })

--- a/services/terraform/bind/main.tf
+++ b/services/terraform/bind/main.tf
@@ -37,6 +37,13 @@ resource "aws_iam_user_policy" "user_policy" {
             "aws:SourceIp" = var.source_ips
           }
         }
+      },
+      {
+        Action: [
+          "logs:FilterLogEvents"
+        ],
+        Effect: "Allow",
+        Resource: "*"
       }
     ]
   })


### PR DESCRIPTION
Add permission so that user can filter CloudWatch log events.

This is the same change I made via the console, and I verified that the change in the console worked.  I'm not sure to verify if this change works, other than by deploying ...